### PR TITLE
Add GHCR publish workflow

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -1,0 +1,47 @@
+name: Publish container image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=sha
+            type=ref,event=branch
+            type=ref,event=tag
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ Build a local image:
 docker build -t docker-cloudflare-tunnel-sync:local .
 ```
 
+Pull the published image from GitHub Container Registry:
+
+```
+docker pull ghcr.io/<owner>/docker-cloudflare-tunnel-sync:latest
+```
+
 Run with Docker (read-only socket mount):
 
 ```


### PR DESCRIPTION
### Motivation

- Provide an automated GitHub Actions workflow to build and publish the container image to GitHub Container Registry on pushes to `main` and on version tags.
- Document how to pull the published image from GHCR in the `README.md` so users can consume published images.

### Description

- Add `.github/workflows/ghcr.yml` which sets up Docker Buildx and uses `docker/build-push-action@v6` to build and push to `ghcr.io/${{ github.repository }}`.
- The workflow logs into GHCR via `docker/login-action@v3` using `GITHUB_TOKEN` and requests `packages: write` permission.
- Image metadata and tags/labels are produced with `docker/metadata-action@v5` and the generated tags are used when pushing.
- Update `README.md` to include a `docker pull ghcr.io/<owner>/docker-cloudflare-tunnel-sync:latest` example.

### Testing

- No automated tests were executed for this change because it is a CI workflow and documentation update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970925a5db08331a860c02b3971c6f9)