### PR TITLE
Add unit tests for Access and Reconcile engines, label parsing, and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  go-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run tests
+        run: go test ./...

--- a/internal/access/engine_test.go
+++ b/internal/access/engine_test.go
@@ -1,0 +1,175 @@
+package access
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/darkdragon/docker-cloudflare-tunnel-sync/internal/cloudflare"
+	"github.com/darkdragon/docker-cloudflare-tunnel-sync/internal/model"
+)
+
+func TestEnsurePoliciesIDOnlyReference(t *testing.T) {
+	api := &stubAccessAPI{}
+	logger := slog.New(slog.NewTextHandler(testWriter{t}, nil))
+	engine := NewEngine(api, logger, false, true)
+
+	app := model.AccessAppSpec{
+		Name: "app",
+		Policies: []model.AccessPolicySpec{
+			{ID: "policy-1", Managed: false},
+		},
+	}
+
+	refs, ok := engine.ensurePolicies(context.Background(), app, map[string]cloudflare.AccessPolicyRecord{}, map[string][]cloudflare.AccessPolicyRecord{})
+	if !ok {
+		t.Fatalf("expected ok to be true")
+	}
+	if len(refs) != 1 || refs[0].ID != "policy-1" {
+		t.Fatalf("unexpected policy refs: %+v", refs)
+	}
+	if api.updatePolicyCalls != 0 {
+		t.Fatalf("expected no policy updates, got %d", api.updatePolicyCalls)
+	}
+}
+
+func TestEnsurePoliciesManagedMissingStops(t *testing.T) {
+	api := &stubAccessAPI{}
+	logger := slog.New(slog.NewTextHandler(testWriter{t}, nil))
+	engine := NewEngine(api, logger, false, true)
+
+	app := model.AccessAppSpec{
+		Name: "app",
+		Policies: []model.AccessPolicySpec{
+			{ID: "missing", Managed: true},
+		},
+	}
+
+	_, ok := engine.ensurePolicies(context.Background(), app, map[string]cloudflare.AccessPolicyRecord{}, map[string][]cloudflare.AccessPolicyRecord{})
+	if ok {
+		t.Fatalf("expected ok to be false when managed policy id is missing")
+	}
+}
+
+func TestUpdatePolicyIfNeededDryRun(t *testing.T) {
+	api := &stubAccessAPI{}
+	logger := slog.New(slog.NewTextHandler(testWriter{t}, nil))
+	engine := NewEngine(api, logger, true, true)
+
+	spec := model.AccessPolicySpec{
+		Name:          "policy",
+		Action:        "allow",
+		IncludeEmails: []string{"user@example.com"},
+		Managed:       true,
+	}
+	record := cloudflare.AccessPolicyRecord{
+		ID:     "policy-id",
+		Name:   "policy",
+		Action: "deny",
+		Include: []cloudflare.AccessRule{
+			{Email: "user@example.com"},
+		},
+	}
+
+	engine.updatePolicyIfNeeded(context.Background(), model.AccessAppSpec{Name: "app"}, spec, record)
+
+	if api.updatePolicyCalls != 0 {
+		t.Fatalf("expected no policy updates during dry-run, got %d", api.updatePolicyCalls)
+	}
+}
+
+func TestReconcileSkipsCreateWhenManageDisabled(t *testing.T) {
+	api := &stubAccessAPI{}
+	logger := slog.New(slog.NewTextHandler(testWriter{t}, nil))
+	engine := NewEngine(api, logger, false, false)
+
+	apps := []model.AccessAppSpec{
+		{
+			Name:   "app",
+			Domain: "app.example.com",
+			Policies: []model.AccessPolicySpec{
+				{ID: "policy-1", Managed: false},
+			},
+		},
+	}
+
+	if err := engine.Reconcile(context.Background(), apps); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if api.createAppCalls != 0 {
+		t.Fatalf("expected no app creation when manage is false, got %d", api.createAppCalls)
+	}
+}
+
+func TestDeleteOrphanedAppsDeletesManaged(t *testing.T) {
+	api := &stubAccessAPI{}
+	logger := slog.New(slog.NewTextHandler(testWriter{t}, nil))
+	engine := NewEngine(api, logger, false, true)
+
+	existing := []cloudflare.AccessAppRecord{
+		{ID: "app-1", Name: "app", Tags: []string{model.AccessManagedTag}},
+	}
+	engine.deleteOrphanedApps(context.Background(), existing, map[string]struct{}{})
+
+	if api.deleteAppCalls != 1 {
+		t.Fatalf("expected 1 delete call, got %d", api.deleteAppCalls)
+	}
+}
+
+type testWriter struct {
+	t *testing.T
+}
+
+func (w testWriter) Write(p []byte) (n int, err error) {
+	w.t.Log(string(p))
+	return len(p), nil
+}
+
+type stubAccessAPI struct {
+	listApps          []cloudflare.AccessAppRecord
+	listPolicies      []cloudflare.AccessPolicyRecord
+	createAppCalls    int
+	updateAppCalls    int
+	deleteAppCalls    int
+	createPolicyCalls int
+	updatePolicyCalls int
+	ensureTagCalls    int
+}
+
+func (api *stubAccessAPI) ListAccessApps(ctx context.Context) ([]cloudflare.AccessAppRecord, error) {
+	return api.listApps, nil
+}
+
+func (api *stubAccessAPI) CreateAccessApp(ctx context.Context, input cloudflare.AccessAppInput) (cloudflare.AccessAppRecord, error) {
+	api.createAppCalls++
+	return cloudflare.AccessAppRecord{ID: "created", Name: input.Name, Domain: input.Domain, Policies: input.Policies, Tags: input.Tags}, nil
+}
+
+func (api *stubAccessAPI) UpdateAccessApp(ctx context.Context, id string, input cloudflare.AccessAppInput) (cloudflare.AccessAppRecord, error) {
+	api.updateAppCalls++
+	return cloudflare.AccessAppRecord{ID: id, Name: input.Name, Domain: input.Domain, Policies: input.Policies, Tags: input.Tags}, nil
+}
+
+func (api *stubAccessAPI) DeleteAccessApp(ctx context.Context, id string) error {
+	api.deleteAppCalls++
+	return nil
+}
+
+func (api *stubAccessAPI) ListAccessPolicies(ctx context.Context) ([]cloudflare.AccessPolicyRecord, error) {
+	return api.listPolicies, nil
+}
+
+func (api *stubAccessAPI) CreateAccessPolicy(ctx context.Context, input cloudflare.AccessPolicyInput) (cloudflare.AccessPolicyRecord, error) {
+	api.createPolicyCalls++
+	return cloudflare.AccessPolicyRecord{ID: "policy", Name: input.Name, Action: input.Action, Include: input.Include}, nil
+}
+
+func (api *stubAccessAPI) UpdateAccessPolicy(ctx context.Context, id string, input cloudflare.AccessPolicyInput) (cloudflare.AccessPolicyRecord, error) {
+	api.updatePolicyCalls++
+	return cloudflare.AccessPolicyRecord{ID: id, Name: input.Name, Action: input.Action, Include: input.Include}, nil
+}
+
+func (api *stubAccessAPI) EnsureAccessTag(ctx context.Context, name string) error {
+	api.ensureTagCalls++
+	return nil
+}

--- a/internal/labels/parser_test.go
+++ b/internal/labels/parser_test.go
@@ -1,0 +1,240 @@
+package labels
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/darkdragon/docker-cloudflare-tunnel-sync/internal/docker"
+)
+
+func TestParseContainers(t *testing.T) {
+	parser := NewParser()
+
+	containers := []docker.ContainerInfo{
+		{
+			ID:   "b",
+			Name: "container-b",
+			Labels: map[string]string{
+				LabelEnable:  "true",
+				LabelHost:    "b.example.com",
+				LabelService: "http://b",
+			},
+		},
+		{
+			ID:   "a",
+			Name: "container-a",
+			Labels: map[string]string{
+				LabelEnable:  "true",
+				LabelHost:    "a.example.com",
+				LabelPath:    "/api",
+				LabelService: "http://a",
+			},
+		},
+		{
+			ID:   "c",
+			Name: "container-c",
+			Labels: map[string]string{
+				LabelEnable: "false",
+				LabelHost:   "ignored.example.com",
+			},
+		},
+	}
+
+	routes, errs := parser.ParseContainers(containers)
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got %v", errs)
+	}
+	if len(routes) != 2 {
+		t.Fatalf("expected 2 routes, got %d", len(routes))
+	}
+	if got := routes[0].Key.String(); got != "a.example.com/api" {
+		t.Fatalf("expected first route to be a.example.com/api, got %s", got)
+	}
+	if got := routes[1].Key.String(); got != "b.example.com" {
+		t.Fatalf("expected second route to be b.example.com, got %s", got)
+	}
+}
+
+func TestParseContainersValidationErrors(t *testing.T) {
+	parser := NewParser()
+
+	containers := []docker.ContainerInfo{
+		{
+			ID:   "1",
+			Name: "missing-host",
+			Labels: map[string]string{
+				LabelEnable:  "true",
+				LabelService: "http://app",
+			},
+		},
+		{
+			ID:   "2",
+			Name: "bad-path",
+			Labels: map[string]string{
+				LabelEnable:  "true",
+				LabelHost:    "example.com",
+				LabelPath:    "api",
+				LabelService: "http://app",
+			},
+		},
+		{
+			ID:   "3",
+			Name: "duplicate-1",
+			Labels: map[string]string{
+				LabelEnable:  "true",
+				LabelHost:    "dup.example.com",
+				LabelService: "http://one",
+			},
+		},
+		{
+			ID:   "4",
+			Name: "duplicate-2",
+			Labels: map[string]string{
+				LabelEnable:  "true",
+				LabelHost:    "dup.example.com",
+				LabelService: "http://two",
+			},
+		},
+		{
+			ID:   "5",
+			Name: "bad-enable",
+			Labels: map[string]string{
+				LabelEnable:  "notabool",
+				LabelHost:    "bad.example.com",
+				LabelService: "http://bad",
+			},
+		},
+	}
+
+	_, errs := parser.ParseContainers(containers)
+	if len(errs) != 4 {
+		t.Fatalf("expected 4 errors, got %d: %v", len(errs), errs)
+	}
+	messages := []string{errs[0].Error(), errs[1].Error(), errs[2].Error(), errs[3].Error()}
+	assertContains(t, messages, "missing required")
+	assertContains(t, messages, "must start with '/'")
+	assertContains(t, messages, "duplicate route definition")
+	assertContains(t, messages, "invalid cloudflare.tunnel.enable label")
+}
+
+func TestParseAccessContainers(t *testing.T) {
+	parser := NewParser()
+
+	containers := []docker.ContainerInfo{
+		{
+			ID:   "1",
+			Name: "access-app",
+			Labels: map[string]string{
+				AccessLabelEnable:                            "true",
+				AccessLabelAppName:                           "internal",
+				AccessLabelAppDomain:                         "internal.example.com",
+				AccessLabelPolicyPrefix + "1.name":           "employees",
+				AccessLabelPolicyPrefix + "1.action":         "allow",
+				AccessLabelPolicyPrefix + "1.include.emails": "a@example.com,b@example.com",
+			},
+		},
+	}
+
+	apps, errs := parser.ParseAccessContainers(containers)
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got %v", errs)
+	}
+	if len(apps) != 1 {
+		t.Fatalf("expected 1 app, got %d", len(apps))
+	}
+	app := apps[0]
+	if app.Name != "internal" || app.Domain != "internal.example.com" {
+		t.Fatalf("unexpected app details: %+v", app)
+	}
+	if len(app.Policies) != 1 {
+		t.Fatalf("expected 1 policy, got %d", len(app.Policies))
+	}
+	policy := app.Policies[0]
+	if !policy.Managed {
+		t.Fatalf("expected managed policy")
+	}
+	if policy.Name != "employees" || policy.Action != "allow" {
+		t.Fatalf("unexpected policy: %+v", policy)
+	}
+	if len(policy.IncludeEmails) != 2 {
+		t.Fatalf("expected 2 include emails, got %d", len(policy.IncludeEmails))
+	}
+}
+
+func TestParseAccessContainersIDOnlyPolicy(t *testing.T) {
+	parser := NewParser()
+
+	containers := []docker.ContainerInfo{
+		{
+			ID:   "1",
+			Name: "access-app",
+			Labels: map[string]string{
+				AccessLabelEnable:                "true",
+				AccessLabelAppName:               "id-only",
+				AccessLabelAppDomain:             "id-only.example.com",
+				AccessLabelPolicyPrefix + "1.id": "policy-id",
+			},
+		},
+	}
+
+	apps, errs := parser.ParseAccessContainers(containers)
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got %v", errs)
+	}
+	if len(apps) != 1 {
+		t.Fatalf("expected 1 app, got %d", len(apps))
+	}
+	policy := apps[0].Policies[0]
+	if policy.Managed {
+		t.Fatalf("expected id-only policy to be unmanaged")
+	}
+	if policy.ID != "policy-id" {
+		t.Fatalf("expected policy id to be policy-id, got %s", policy.ID)
+	}
+}
+
+func TestParseAccessContainersErrors(t *testing.T) {
+	parser := NewParser()
+
+	containers := []docker.ContainerInfo{
+		{
+			ID:   "1",
+			Name: "missing-app-name",
+			Labels: map[string]string{
+				AccessLabelEnable:    "true",
+				AccessLabelAppDomain: "example.com",
+			},
+		},
+		{
+			ID:   "2",
+			Name: "bad-policy",
+			Labels: map[string]string{
+				AccessLabelEnable:                  "true",
+				AccessLabelAppName:                 "app",
+				AccessLabelAppDomain:               "app.example.com",
+				AccessLabelPolicyPrefix + "0.name": "invalid",
+			},
+		},
+	}
+
+	_, errs := parser.ParseAccessContainers(containers)
+	if len(errs) < 2 {
+		t.Fatalf("expected at least 2 errors, got %d: %v", len(errs), errs)
+	}
+	messages := make([]string, 0, len(errs))
+	for _, err := range errs {
+		messages = append(messages, err.Error())
+	}
+	assertContains(t, messages, "missing required")
+	assertContains(t, messages, "invalid access policy index")
+}
+
+func assertContains(t *testing.T, messages []string, needle string) {
+	t.Helper()
+	for _, message := range messages {
+		if strings.Contains(message, needle) {
+			return
+		}
+	}
+	t.Fatalf("expected error containing %q, got %v", needle, messages)
+}

--- a/internal/reconcile/engine_test.go
+++ b/internal/reconcile/engine_test.go
@@ -1,0 +1,117 @@
+package reconcile
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/darkdragon/docker-cloudflare-tunnel-sync/internal/cloudflare"
+	"github.com/darkdragon/docker-cloudflare-tunnel-sync/internal/model"
+)
+
+func TestBuildDesiredIngress(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(testWriter{t}, nil))
+	engine := NewEngine(nil, logger, false, true)
+
+	existing := []cloudflare.IngressRule{
+		{Hostname: "b.example.com", Service: "http://b1"},
+		{Hostname: "b.example.com", Service: "http://b2"},
+		{Hostname: "a.example.com", Path: "/app", Service: "http://a", OriginRequest: []byte(`{"noTLSVerify":true}`)},
+		{Service: model.FallbackService},
+	}
+	desired := []model.RouteSpec{
+		{Key: model.RouteKey{Hostname: "a.example.com", Path: "/app"}, Service: "http://a"},
+		{Key: model.RouteKey{Hostname: "c.example.com"}, Service: "http://c"},
+	}
+
+	desiredIngress, removed := engine.buildDesiredIngress(desired, existing)
+
+	if len(removed) != 1 {
+		t.Fatalf("expected 1 removed rule, got %d", len(removed))
+	}
+	if removed[0].Hostname != "b.example.com" || removed[0].Service != "http://b1" {
+		t.Fatalf("unexpected removed rule: %+v", removed[0])
+	}
+
+	if len(desiredIngress) != 3 {
+		t.Fatalf("expected 3 desired rules, got %d", len(desiredIngress))
+	}
+	if desiredIngress[0].Hostname != "a.example.com" || desiredIngress[0].Path != "/app" {
+		t.Fatalf("unexpected first desired rule: %+v", desiredIngress[0])
+	}
+	if string(desiredIngress[0].OriginRequest) == "" {
+		t.Fatalf("expected origin request to be preserved")
+	}
+	if desiredIngress[1].Hostname != "c.example.com" {
+		t.Fatalf("unexpected second desired rule: %+v", desiredIngress[1])
+	}
+	if desiredIngress[2].Service != model.FallbackService {
+		t.Fatalf("expected fallback rule at end")
+	}
+}
+
+func TestIngressEqual(t *testing.T) {
+	ruleA := cloudflare.IngressRule{Hostname: "a.example.com", Service: "http://a"}
+	ruleB := cloudflare.IngressRule{Hostname: "a.example.com", Service: "http://a", OriginRequest: []byte(`{"noTLSVerify":true}`)}
+
+	if ingressEqual([]cloudflare.IngressRule{ruleA}, []cloudflare.IngressRule{ruleA}) != true {
+		t.Fatalf("expected ingressEqual to return true")
+	}
+	if ingressEqual([]cloudflare.IngressRule{ruleA}, []cloudflare.IngressRule{ruleB}) {
+		t.Fatalf("expected ingressEqual to detect origin request differences")
+	}
+}
+
+type testWriter struct {
+	t *testing.T
+}
+
+func (w testWriter) Write(p []byte) (n int, err error) {
+	w.t.Log(string(p))
+	return len(p), nil
+}
+
+func TestEngineReconcileNoChanges(t *testing.T) {
+	ctx := context.Background()
+	api := &stubAPI{config: cloudflare.TunnelConfig{Ingress: []cloudflare.IngressRule{{Hostname: "a.example.com", Service: "http://a"}, {Service: model.FallbackService}}}}
+	logger := slog.New(slog.NewTextHandler(testWriter{t}, nil))
+	engine := NewEngine(api, logger, false, true)
+
+	err := engine.Reconcile(ctx, []model.RouteSpec{{Key: model.RouteKey{Hostname: "a.example.com"}, Service: "http://a"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if api.updated {
+		t.Fatalf("expected no update when ingress matches")
+	}
+}
+
+func TestEngineReconcileManageDisabledSkipsUpdate(t *testing.T) {
+	ctx := context.Background()
+	api := &stubAPI{config: cloudflare.TunnelConfig{Ingress: []cloudflare.IngressRule{{Hostname: "a.example.com", Service: "http://a"}, {Service: model.FallbackService}}}}
+	logger := slog.New(slog.NewTextHandler(testWriter{t}, nil))
+	engine := NewEngine(api, logger, false, false)
+
+	err := engine.Reconcile(ctx, []model.RouteSpec{{Key: model.RouteKey{Hostname: "b.example.com"}, Service: "http://b"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if api.updated {
+		t.Fatalf("expected no update when manage tunnel is false")
+	}
+}
+
+type stubAPI struct {
+	config  cloudflare.TunnelConfig
+	updated bool
+}
+
+func (api *stubAPI) GetConfig(ctx context.Context) (cloudflare.TunnelConfig, error) {
+	return api.config, nil
+}
+
+func (api *stubAPI) UpdateConfig(ctx context.Context, config cloudflare.TunnelConfig) error {
+	api.updated = true
+	api.config = config
+	return nil
+}


### PR DESCRIPTION
### Motivation
- Improve confidence in code paths that reconcile Cloudflare Access apps/policies and tunnel ingress by adding unit tests that exercise creation, update, dry-run and manage-flag branches.
- Validate label parsing logic for container-to-route and container-to-access conversions and surface validation errors.
- Run tests automatically on CI to catch regressions early.

### Description
- Add `internal/access/engine_test.go` which provides unit tests for Access flows including `TestEnsurePoliciesIDOnlyReference`, `TestEnsurePoliciesManagedMissingStops`, `TestUpdatePolicyIfNeededDryRun`, `TestReconcileSkipsCreateWhenManageDisabled`, `TestDeleteOrphanedAppsDeletesManaged`, and a `stubAccessAPI` test double plus a `testWriter` logger helper.
- Extend `internal/reconcile/engine_test.go` with `TestEngineReconcileManageDisabledSkipsUpdate` and a `testWriter` helper to cover the manage-flag path that should skip tunnel updates.
- Add `internal/labels/parser_test.go` with tests covering parsing of container labels into routes and access apps, including validation error scenarios and duplicate detection.
- Add a GitHub Actions workflow at `.github/workflows/tests.yml` to run `go test ./...` on PRs and pushes to `main`, and run `gofmt` on added test files.

### Testing
- Ran `go test ./internal/... ./cmd/...` and all tested packages succeeded (notably `internal/access`, `internal/labels`, and `internal/reconcile`).
- Ran `go test -v ./internal/access` to verify Access engine test output and it passed. 
- Formatting was applied with `gofmt -w` on the modified test files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69709c9f790883319f142ba3b452ede1)