### PR TITLE
Fix access engine tests for managed tag input

### DIFF
--- a/internal/access/engine_test.go
+++ b/internal/access/engine_test.go
@@ -9,10 +9,12 @@ import (
 	"github.com/darkdragon/docker-cloudflare-tunnel-sync/internal/model"
 )
 
+const testManagedBy = "test-managed"
+
 func TestEnsurePoliciesIDOnlyReference(t *testing.T) {
 	api := &stubAccessAPI{}
 	logger := slog.New(slog.NewTextHandler(testWriter{t}, nil))
-	engine := NewEngine(api, logger, false, true)
+	engine := NewEngine(api, logger, false, true, testManagedBy)
 
 	app := model.AccessAppSpec{
 		Name: "app",
@@ -36,7 +38,7 @@ func TestEnsurePoliciesIDOnlyReference(t *testing.T) {
 func TestEnsurePoliciesManagedMissingStops(t *testing.T) {
 	api := &stubAccessAPI{}
 	logger := slog.New(slog.NewTextHandler(testWriter{t}, nil))
-	engine := NewEngine(api, logger, false, true)
+	engine := NewEngine(api, logger, false, true, testManagedBy)
 
 	app := model.AccessAppSpec{
 		Name: "app",
@@ -54,7 +56,7 @@ func TestEnsurePoliciesManagedMissingStops(t *testing.T) {
 func TestUpdatePolicyIfNeededDryRun(t *testing.T) {
 	api := &stubAccessAPI{}
 	logger := slog.New(slog.NewTextHandler(testWriter{t}, nil))
-	engine := NewEngine(api, logger, true, true)
+	engine := NewEngine(api, logger, true, true, testManagedBy)
 
 	spec := model.AccessPolicySpec{
 		Name:          "policy",
@@ -81,7 +83,7 @@ func TestUpdatePolicyIfNeededDryRun(t *testing.T) {
 func TestReconcileSkipsCreateWhenManageDisabled(t *testing.T) {
 	api := &stubAccessAPI{}
 	logger := slog.New(slog.NewTextHandler(testWriter{t}, nil))
-	engine := NewEngine(api, logger, false, false)
+	engine := NewEngine(api, logger, false, false, testManagedBy)
 
 	apps := []model.AccessAppSpec{
 		{
@@ -104,10 +106,10 @@ func TestReconcileSkipsCreateWhenManageDisabled(t *testing.T) {
 func TestDeleteOrphanedAppsDeletesManaged(t *testing.T) {
 	api := &stubAccessAPI{}
 	logger := slog.New(slog.NewTextHandler(testWriter{t}, nil))
-	engine := NewEngine(api, logger, false, true)
+	engine := NewEngine(api, logger, false, true, testManagedBy)
 
 	existing := []cloudflare.AccessAppRecord{
-		{ID: "app-1", Name: "app", Tags: []string{model.AccessManagedTag}},
+		{ID: "app-1", Name: "app", Tags: []string{model.AccessManagedTag(testManagedBy)}},
 	}
 	engine.deleteOrphanedApps(context.Background(), existing, map[string]struct{}{})
 


### PR DESCRIPTION
### Motivation
- Tests needed to be updated to match the new `NewEngine` constructor signature that accepts a managed-by value and to assert the fully qualified managed tag string.

### Description
- Update `internal/access/engine_test.go` to pass a `testManagedBy` string into `NewEngine` and to use `model.AccessManagedTag(testManagedBy)` when asserting tagged apps, and run `gofmt` on the modified file.

### Testing
- Ran `GOTOOLCHAIN=local go test ./...` and the test suite passed for the modified package and related packages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971f421f7ec8331af577b072631595f)