### PR TITLE
Add origin TLS labels for tunnel ingress routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ All labels are explicit and namespaced. A container is only managed when `cloudf
 | `cloudflare.tunnel.hostname` | yes | `app.example.com` | Hostname for the route. |
 | `cloudflare.tunnel.service` | yes | `http://api:8080` | Cloudflare service/origin URL. |
 | `cloudflare.tunnel.path` | no | `/api` | Optional path prefix (must start with `/`). |
+| `cloudflare.tunnel.origin.server-name` | no | `app.internal` | Sets `originRequest.originServerName` (TLS SNI override) for the route. |
+| `cloudflare.tunnel.origin.no-tls-verify` | no | `true` | Sets `originRequest.noTLSVerify` for the route (`true`/`false`). |
+
+When either origin label is omitted, the corresponding `originRequest` key is removed during reconciliation. Unmanaged `originRequest` keys are preserved.
 
 ### Access labels
 

--- a/internal/model/route.go
+++ b/internal/model/route.go
@@ -23,7 +23,9 @@ type SourceRef struct {
 
 // RouteSpec describes the desired ingress rule state derived from Docker labels.
 type RouteSpec struct {
-	Key     RouteKey
-	Service string
-	Source  SourceRef
+	Key              RouteKey
+	Service          string
+	OriginServerName *string
+	NoTLSVerify      *bool
+	Source           SourceRef
 }


### PR DESCRIPTION
## Summary
- add support for `cloudflare.tunnel.origin.server-name` and `cloudflare.tunnel.origin.no-tls-verify` labels in tunnel route parsing
- reconcile `originRequest.originServerName` and `originRequest.noTLSVerify` declaratively: set when labels are present, delete when labels are removed, and preserve unmanaged `originRequest` keys
- extend parser/reconcile tests and document the new labels and semantics in the README

## Testing
- `docker run --rm -v \"$PWD:/work\" -w /work golang:1.24 gofmt -w internal/model/route.go internal/labels/parser.go internal/labels/parser_test.go internal/reconcile/engine.go internal/reconcile/engine_test.go`
- `docker run --rm -v \"$PWD:/work\" -w /work golang:1.24 go test ./...`

Closes #10