### PR TITLE
Support zone-scoped DNS cleanup and overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,8 @@ Start the container — it is automatically exposed.
 | `SYNC_MANAGED_TUNNEL` | no | `false` | Allow this tool to overwrite the tunnel ingress configuration. |
 | `SYNC_MANAGED_ACCESS` | no | `false` | Allow this tool to create/update Access apps and policies. |
 | `SYNC_MANAGED_DNS` | no | `false` | Allow this tool to create/update DNS CNAME records for tunnel hostnames. |
-| `SYNC_DELETE_DNS` | no | `false` | Delete managed DNS records when hostnames are no longer labeled. |
+| `SYNC_DNS_ZONES` | no | - | Comma-separated DNS zones to keep scanning for orphan cleanup when `SYNC_DELETE_DNS=true`, even if no current labels resolve to those zones. |
+| `SYNC_DELETE_DNS` | no | `false` | Delete managed DNS records in zones selected from current labels plus any zones listed in `SYNC_DNS_ZONES`. This does not perform a full account-wide cleanup. |
 | `SYNC_MANAGED_BY` | no | `docker-cf-tunnel-sync` | Override the managed-by tag/comment value (used for Access tags and DNS comments). |
 | `LOG_LEVEL` | no | `info` | `debug`, `info`, `warn`, or `error`. |
 
@@ -157,6 +158,7 @@ All labels are explicit and namespaced. A container is only managed when `cloudf
 | `cloudflare.tunnel.enable` | yes | `true` | Opt-in flag for route creation. |
 | `cloudflare.tunnel.hostname` | yes | `app.example.com` | Base route hostname (required). |
 | `cloudflare.tunnel.service` | yes | `http://api:8080` | Base route service/origin URL (required). |
+| `cloudflare.tunnel.dns.zone` | no | `dev.example.com` | Override automatic DNS zone selection for this route hostname. Useful when Cloudflare manages a delegated sub-zone. |
 | `cloudflare.tunnel.path` | no | `/api` | Optional base route path prefix (must start with `/`). |
 | `cloudflare.tunnel.origin.server-name` | no | `app.internal` | Optional base route `originRequest.originServerName` (TLS SNI override). |
 | `cloudflare.tunnel.origin.no-tls-verify` | no | `true` | Optional base route `originRequest.noTLSVerify` (`true`/`false`). |
@@ -168,6 +170,7 @@ All labels are explicit and namespaced. A container is only managed when `cloudf
 > You can define additional routes with suffix-based labels:
 > - `cloudflare.tunnel.hostname.<suffix>`
 > - `cloudflare.tunnel.service.<suffix>`
+> - `cloudflare.tunnel.dns.zone.<suffix>`
 > - `cloudflare.tunnel.path.<suffix>`
 > - `cloudflare.tunnel.origin.server-name.<suffix>`
 > - `cloudflare.tunnel.origin.no-tls-verify.<suffix>`
@@ -177,6 +180,20 @@ All labels are explicit and namespaced. A container is only managed when `cloudf
 > Empty suffix labels (for example `cloudflare.tunnel.hostname.`) are ignored.
 
 When either origin label is omitted for a managed route, the corresponding `originRequest` key is removed during reconciliation. Unmanaged `originRequest` keys are preserved.
+
+DNS sync derives the target zone automatically from each hostname using the effective eTLD+1. For example, `app.dev.example.com` defaults to `example.com`. Set `cloudflare.tunnel.dns.zone` (or `cloudflare.tunnel.dns.zone.<suffix>`) to target a more specific Cloudflare zone such as `dev.example.com`.
+
+The DNS engine only queries zones selected by these rules. When `SYNC_DELETE_DNS=true`, you can extend that scan scope with `SYNC_DNS_ZONES`. This is useful when an entire zone disappears from current labels but you still want the controller to delete old managed DNS records in that zone.
+
+Example:
+
+```bash
+-e SYNC_MANAGED_DNS=true \
+-e SYNC_DELETE_DNS=true \
+-e SYNC_DNS_ZONES=darkdragon.fr,cf.darkdragon.fr
+```
+
+`cloudflare.tunnel.dns.zone` selects the Cloudflare zone for a specific hostname. `SYNC_DNS_ZONES` is different: it only keeps whole zones in the cleanup scan set when deleting orphaned DNS records.
 
 ### Access labels
 

--- a/cmd/docker-cloudflare-tunnel-sync/main.go
+++ b/cmd/docker-cloudflare-tunnel-sync/main.go
@@ -43,7 +43,7 @@ func main() {
 
 	parser := labels.NewParser()
 	reconciler := reconcile.NewEngine(cloudflareClient, logger, cfg.Controller.DryRun, cfg.Controller.ManageTunnel)
-	dnsEngine := dns.NewEngine(cloudflareClient, logger, cfg.Controller.DryRun, cfg.Controller.ManageDNS, cfg.Controller.DeleteDNS, cfg.Cloudflare.TunnelID, cfg.ManagedBy)
+	dnsEngine := dns.NewEngine(cloudflareClient, logger, cfg.Controller.DryRun, cfg.Controller.ManageDNS, cfg.Controller.DeleteDNS, cfg.Controller.DNSZones, cfg.Cloudflare.TunnelID, cfg.ManagedBy)
 	accessEngine := access.NewEngine(cloudflareClient, logger, cfg.Controller.DryRun, cfg.Controller.ManageAccess, cfg.ManagedBy)
 	controller := controller.NewController(dockerAdapter, parser, reconciler, dnsEngine, accessEngine, cfg.Controller.PollInterval, logger)
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,10 @@ go 1.24.0
 
 toolchain go1.24.12
 
-require github.com/docker/docker v26.1.4+incompatible
+require (
+	github.com/docker/docker v26.1.4+incompatible
+	golang.org/x/net v0.47.0
+)
 
 require (
 	github.com/Microsoft/go-winio v0.4.21 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,7 @@ type ControllerConfig struct {
 	ManageTunnel bool
 	ManageAccess bool
 	ManageDNS    bool
+	DNSZones     []string
 	DeleteDNS    bool
 }
 
@@ -72,6 +73,7 @@ func Load() (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	dnsZones := parseDNSZonesEnv("SYNC_DNS_ZONES")
 
 	managedBy := strings.TrimSpace(os.Getenv("SYNC_MANAGED_BY"))
 
@@ -111,6 +113,7 @@ func Load() (Config, error) {
 			ManageTunnel: manageTunnel,
 			ManageAccess: manageAccess,
 			ManageDNS:    manageDNS,
+			DNSZones:     dnsZones,
 			DeleteDNS:    deleteDNS,
 		},
 		ManagedBy: managedBy,
@@ -132,6 +135,29 @@ func getEnvDefault(key, fallback string) string {
 		return fallback
 	}
 	return value
+}
+
+func parseDNSZonesEnv(key string) []string {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return nil
+	}
+
+	seen := map[string]struct{}{}
+	zones := []string{}
+	for _, part := range strings.Split(value, ",") {
+		zone := strings.ToLower(strings.TrimSuffix(strings.TrimSpace(part), "."))
+		if zone == "" {
+			continue
+		}
+		if _, ok := seen[zone]; ok {
+			continue
+		}
+		seen[zone] = struct{}{}
+		zones = append(zones, zone)
+	}
+
+	return zones
 }
 
 func parseBoolEnv(key string, fallback bool) (bool, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,39 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestLoadParsesDNSZones(t *testing.T) {
+	t.Setenv("CF_API_TOKEN", "token")
+	t.Setenv("CF_ACCOUNT_ID", "account")
+	t.Setenv("CF_TUNNEL_ID", "tunnel")
+	t.Setenv("SYNC_DNS_ZONES", "darkdragon.fr, cf.darkdragon.fr. ,darkdragon.fr,,CF.Darkdragon.FR")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []string{"darkdragon.fr", "cf.darkdragon.fr"}
+	if !reflect.DeepEqual(cfg.Controller.DNSZones, want) {
+		t.Fatalf("unexpected DNS zones: got %+v want %+v", cfg.Controller.DNSZones, want)
+	}
+}
+
+func TestLoadDefaultsEmptyDNSZones(t *testing.T) {
+	t.Setenv("CF_API_TOKEN", "token")
+	t.Setenv("CF_ACCOUNT_ID", "account")
+	t.Setenv("CF_TUNNEL_ID", "tunnel")
+	t.Setenv("SYNC_DNS_ZONES", "  , ,  ")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(cfg.Controller.DNSZones) != 0 {
+		t.Fatalf("expected no DNS zones, got %+v", cfg.Controller.DNSZones)
+	}
+}

--- a/internal/dns/engine.go
+++ b/internal/dns/engine.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/darkdragon/docker-cloudflare-tunnel-sync/internal/cloudflare"
 	"github.com/darkdragon/docker-cloudflare-tunnel-sync/internal/model"
+	"golang.org/x/net/publicsuffix"
 )
 
 const (
@@ -19,25 +20,37 @@ const (
 
 // Engine reconciles DNS records for tunnel hostnames.
 type Engine struct {
-	api            cloudflare.DNSAPI
-	log            *slog.Logger
-	dryRun         bool
-	manage         bool
-	delete         bool
-	tunnelID       string
-	managedComment string
+	api             cloudflare.DNSAPI
+	log             *slog.Logger
+	dryRun          bool
+	manage          bool
+	delete          bool
+	configuredZones []string
+	tunnelID        string
+	managedComment  string
 }
 
-func NewEngine(api cloudflare.DNSAPI, logger *slog.Logger, dryRun bool, manage bool, delete bool, tunnelID string, managedBy string) *Engine {
+func NewEngine(api cloudflare.DNSAPI, logger *slog.Logger, dryRun bool, manage bool, delete bool, configuredZones []string, tunnelID string, managedBy string) *Engine {
 	return &Engine{
-		api:            api,
-		log:            logger,
-		dryRun:         dryRun,
-		manage:         manage,
-		delete:         delete,
-		tunnelID:       tunnelID,
-		managedComment: model.DNSManagedComment(managedBy),
+		api:             api,
+		log:             logger,
+		dryRun:          dryRun,
+		manage:          manage,
+		delete:          delete,
+		configuredZones: append([]string(nil), configuredZones...),
+		tunnelID:        tunnelID,
+		managedComment:  model.DNSManagedComment(managedBy),
 	}
+}
+
+type zonePlan struct {
+	requiredZones   map[string]struct{}
+	hostnamesByZone map[string][]string
+}
+
+type hostnameZoneState struct {
+	explicitZones   map[string]struct{}
+	invalidExplicit bool
 }
 
 func (engine *Engine) Reconcile(ctx context.Context, routes []model.RouteSpec) error {
@@ -45,8 +58,10 @@ func (engine *Engine) Reconcile(ctx context.Context, routes []model.RouteSpec) e
 		return nil
 	}
 
-	hostnames := uniqueHostnames(routes)
-	if len(hostnames) == 0 && !engine.delete {
+	plan := buildZonePlan(routes, engine.log)
+	selectedZones := engine.selectedZones(plan)
+	if len(selectedZones) == 0 {
+		engine.log.Debug("no DNS zones selected from managed hostnames or configured cleanup zones; DNS sync skipped")
 		return nil
 	}
 
@@ -59,37 +74,50 @@ func (engine *Engine) Reconcile(ctx context.Context, routes []model.RouteSpec) e
 		return nil
 	}
 
-	orderedZones := orderZones(zones)
+	orderedZones := filterZones(zones, selectedZones, engine.log)
+	if len(orderedZones) == 0 {
+		engine.log.Warn("no matching Cloudflare zones found for managed hostnames or configured cleanup zones; DNS sync skipped")
+		return nil
+	}
+
 	for _, zone := range orderedZones {
-		knownHostnames := filterHostnamesForZone(hostnames, zone.Name)
+		zoneName := normalizeDNSName(zone.Name)
+		knownHostnames := append([]string(nil), plan.hostnamesByZone[zoneName]...)
+		if len(knownHostnames) == 0 && !engine.delete {
+			continue
+		}
+
 		byName := map[string]struct{}{}
 		for _, hostname := range knownHostnames {
 			byName[hostname] = struct{}{}
 		}
 
-		records, err := engine.api.ListDNSRecords(ctx, zone.ID, dnsRecordType, "")
-		if err != nil {
-			engine.log.Error("failed to list DNS records", "zone", zone.Name, "error", err)
-			continue
-		}
+		if engine.delete {
+			if len(knownHostnames) == 0 {
+				engine.log.Debug("scanning configured DNS zone for orphan cleanup", "zone", zone.Name)
+			}
 
-		for _, record := range records {
-			hostname := strings.ToLower(strings.TrimSuffix(record.Name, "."))
-			if _, ok := byName[hostname]; ok {
+			records, err := engine.api.ListDNSRecords(ctx, zone.ID, dnsRecordType, "")
+			if err != nil {
+				engine.log.Error("failed to list DNS records", "zone", zone.Name, "error", err)
 				continue
 			}
-			if !engine.delete {
-				continue
-			}
-			if record.Comment != engine.managedComment {
-				continue
-			}
-			engine.log.Warn("deleting managed DNS record no longer desired", "hostname", hostname, "zone", zone.Name)
-			if engine.dryRun {
-				continue
-			}
-			if err := engine.api.DeleteDNSRecord(ctx, zone.ID, record.ID); err != nil {
-				engine.log.Error("failed to delete DNS record", "hostname", hostname, "zone", zone.Name, "error", err)
+
+			for _, record := range records {
+				hostname := strings.ToLower(strings.TrimSuffix(record.Name, "."))
+				if _, ok := byName[hostname]; ok {
+					continue
+				}
+				if record.Comment != engine.managedComment {
+					continue
+				}
+				engine.log.Warn("deleting managed DNS record no longer desired", "hostname", hostname, "zone", zone.Name)
+				if engine.dryRun {
+					continue
+				}
+				if err := engine.api.DeleteDNSRecord(ctx, zone.ID, record.ID); err != nil {
+					engine.log.Error("failed to delete DNS record", "hostname", hostname, "zone", zone.Name, "error", err)
+				}
 			}
 		}
 
@@ -164,55 +192,177 @@ func (engine *Engine) isManagedRecord(record cloudflare.DNSRecord, desired cloud
 	return strings.EqualFold(record.Content, desired.Content)
 }
 
-func uniqueHostnames(routes []model.RouteSpec) []string {
-	seen := map[string]struct{}{}
-	items := make([]string, 0, len(routes))
-	for _, route := range routes {
-		host := strings.TrimSpace(route.Key.Hostname)
-		if host == "" {
-			continue
-		}
-		host = strings.ToLower(strings.TrimSuffix(host, "."))
-		if _, ok := seen[host]; ok {
-			continue
-		}
-		seen[host] = struct{}{}
-		items = append(items, host)
+func (engine *Engine) selectedZones(plan zonePlan) map[string]struct{} {
+	selected := map[string]struct{}{}
+	for zone := range plan.requiredZones {
+		selected[zone] = struct{}{}
 	}
-	sort.Strings(items)
-	return items
+	if !engine.delete {
+		return selected
+	}
+
+	for _, zone := range engine.configuredZones {
+		normalized := normalizeDNSName(zone)
+		if normalized == "" {
+			continue
+		}
+		if _, ok := selected[normalized]; ok {
+			continue
+		}
+		engine.log.Debug("configured DNS cleanup zone selected", "zone", normalized)
+		selected[normalized] = struct{}{}
+	}
+
+	return selected
+}
+
+func buildZonePlan(routes []model.RouteSpec, logger *slog.Logger) zonePlan {
+	states := map[string]*hostnameZoneState{}
+
+	for _, route := range routes {
+		hostname := normalizeDNSName(route.Key.Hostname)
+		if hostname == "" {
+			continue
+		}
+
+		state, ok := states[hostname]
+		if !ok {
+			state = &hostnameZoneState{explicitZones: map[string]struct{}{}}
+			states[hostname] = state
+		}
+
+		if route.DNSZoneOverride == "" {
+			continue
+		}
+
+		zone := normalizeDNSName(route.DNSZoneOverride)
+		if zone == "" {
+			logger.Warn("configured DNS zone override is empty; skipping hostname", "hostname", hostname)
+			state.invalidExplicit = true
+			continue
+		}
+		if !hostnameMatchesZone(hostname, zone) {
+			logger.Warn("configured DNS zone override does not match hostname; skipping hostname", "hostname", hostname, "zone", zone)
+			state.invalidExplicit = true
+			continue
+		}
+
+		state.explicitZones[zone] = struct{}{}
+	}
+
+	plan := zonePlan{
+		requiredZones:   map[string]struct{}{},
+		hostnamesByZone: map[string][]string{},
+	}
+
+	for hostname, state := range states {
+		if state.invalidExplicit {
+			continue
+		}
+
+		zone, ok := selectZoneForHostname(hostname, state, logger)
+		if !ok {
+			continue
+		}
+
+		plan.requiredZones[zone] = struct{}{}
+		plan.hostnamesByZone[zone] = append(plan.hostnamesByZone[zone], hostname)
+	}
+
+	for zone := range plan.hostnamesByZone {
+		sort.Strings(plan.hostnamesByZone[zone])
+	}
+
+	return plan
 }
 
 func orderZones(zones []cloudflare.Zone) []cloudflare.Zone {
 	ordered := make([]cloudflare.Zone, len(zones))
 	copy(ordered, zones)
 	sort.SliceStable(ordered, func(i, j int) bool {
-		return len(ordered[i].Name) > len(ordered[j].Name)
+		left := normalizeDNSName(ordered[i].Name)
+		right := normalizeDNSName(ordered[j].Name)
+		if len(left) == len(right) {
+			return left < right
+		}
+		return len(left) > len(right)
 	})
 	return ordered
 }
 
-func matchZone(hostname string, zones []cloudflare.Zone) (cloudflare.Zone, bool) {
-	lower := strings.ToLower(strings.TrimSuffix(hostname, "."))
+func filterZones(zones []cloudflare.Zone, requiredZones map[string]struct{}, logger *slog.Logger) []cloudflare.Zone {
+	filtered := make([]cloudflare.Zone, 0, len(requiredZones))
+	found := map[string]struct{}{}
+
 	for _, zone := range zones {
-		zoneName := strings.ToLower(strings.TrimSuffix(zone.Name, "."))
-		if lower == zoneName || strings.HasSuffix(lower, "."+zoneName) {
+		normalized := normalizeDNSName(zone.Name)
+		if _, ok := requiredZones[normalized]; !ok {
+			logger.Debug("skipping unrelated DNS zone", "zone", zone.Name)
+			continue
+		}
+		filtered = append(filtered, zone)
+		found[normalized] = struct{}{}
+	}
+
+	for _, zone := range missingZones(requiredZones, found) {
+		logger.Warn("required DNS zone not found in accessible Cloudflare zones; skipping", "zone", zone)
+	}
+
+	return orderZones(filtered)
+}
+
+func selectZoneForHostname(hostname string, state *hostnameZoneState, logger *slog.Logger) (string, bool) {
+	if len(state.explicitZones) > 1 {
+		zones := make([]string, 0, len(state.explicitZones))
+		for zone := range state.explicitZones {
+			zones = append(zones, zone)
+		}
+		sort.Strings(zones)
+		logger.Warn("conflicting DNS zone overrides for hostname; skipping hostname", "hostname", hostname, "zones", strings.Join(zones, ","))
+		return "", false
+	}
+
+	if len(state.explicitZones) == 1 {
+		for zone := range state.explicitZones {
 			return zone, true
 		}
 	}
-	return cloudflare.Zone{}, false
+
+	zone, err := autoZoneForHostname(hostname)
+	if err != nil {
+		logger.Warn("failed to derive DNS zone from hostname; skipping hostname", "hostname", hostname, "error", err)
+		return "", false
+	}
+
+	return zone, true
 }
 
-func filterHostnamesForZone(hostnames []string, zoneName string) []string {
-	items := []string{}
-	lowerZone := strings.ToLower(strings.TrimSuffix(zoneName, "."))
-	for _, hostname := range hostnames {
-		lower := strings.ToLower(strings.TrimSuffix(hostname, "."))
-		if lower == lowerZone || strings.HasSuffix(lower, "."+lowerZone) {
-			items = append(items, lower)
-		}
+func autoZoneForHostname(hostname string) (string, error) {
+	zone, err := publicsuffix.EffectiveTLDPlusOne(hostname)
+	if err != nil {
+		return "", err
 	}
-	return items
+	return normalizeDNSName(zone), nil
+}
+
+func missingZones(requiredZones map[string]struct{}, found map[string]struct{}) []string {
+	missing := make([]string, 0)
+	for zone := range requiredZones {
+		if _, ok := found[zone]; ok {
+			continue
+		}
+		missing = append(missing, zone)
+	}
+	sort.Strings(missing)
+	return missing
+}
+
+func normalizeDNSName(value string) string {
+	return strings.ToLower(strings.TrimSuffix(strings.TrimSpace(value), "."))
+}
+
+func hostnameMatchesZone(hostname string, zone string) bool {
+	return hostname == zone || strings.HasSuffix(hostname, "."+zone)
 }
 
 func dnsRecordEqual(record cloudflare.DNSRecord, desired cloudflare.DNSRecordInput) bool {

--- a/internal/dns/engine_test.go
+++ b/internal/dns/engine_test.go
@@ -1,0 +1,314 @@
+package dns
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/darkdragon/docker-cloudflare-tunnel-sync/internal/cloudflare"
+	"github.com/darkdragon/docker-cloudflare-tunnel-sync/internal/model"
+)
+
+const testManagedBy = "test-managed"
+
+func TestBuildZonePlanPrefersExplicitOverride(t *testing.T) {
+	plan := buildZonePlan([]model.RouteSpec{
+		{Key: model.RouteKey{Hostname: "app.dev.example.com"}, Service: "http://app"},
+		{Key: model.RouteKey{Hostname: "app.dev.example.com", Path: "/api"}, Service: "http://app-api", DNSZoneOverride: "dev.example.com"},
+	}, testLogger())
+
+	if _, ok := plan.requiredZones["dev.example.com"]; !ok {
+		t.Fatalf("expected explicit zone override to be selected, got %+v", plan.requiredZones)
+	}
+	if _, ok := plan.requiredZones["example.com"]; ok {
+		t.Fatalf("did not expect auto-derived example.com when explicit override exists")
+	}
+	hosts := plan.hostnamesByZone["dev.example.com"]
+	if len(hosts) != 1 || hosts[0] != "app.dev.example.com" {
+		t.Fatalf("unexpected hostnames for explicit zone: %+v", hosts)
+	}
+}
+
+func TestBuildZonePlanSkipsConflictingExplicitOverrides(t *testing.T) {
+	plan := buildZonePlan([]model.RouteSpec{
+		{Key: model.RouteKey{Hostname: "app.dev.example.com"}, Service: "http://app", DNSZoneOverride: "dev.example.com"},
+		{Key: model.RouteKey{Hostname: "app.dev.example.com", Path: "/api"}, Service: "http://app-api", DNSZoneOverride: "example.com"},
+	}, testLogger())
+
+	if len(plan.requiredZones) != 0 {
+		t.Fatalf("expected conflicting overrides to skip hostname, got %+v", plan.requiredZones)
+	}
+	if len(plan.hostnamesByZone) != 0 {
+		t.Fatalf("expected no hostname plan for conflicting overrides, got %+v", plan.hostnamesByZone)
+	}
+}
+
+func TestReconcileManageDisabledSkipsAPICalls(t *testing.T) {
+	api := &stubDNSAPI{}
+	engine := NewEngine(api, testLogger(), false, false, true, nil, "tunnel-id", testManagedBy)
+
+	err := engine.Reconcile(context.Background(), []model.RouteSpec{{Key: model.RouteKey{Hostname: "app.example.com"}, Service: "http://app"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if api.listZonesCalls != 0 {
+		t.Fatalf("expected no zone listing when manage is false, got %d", api.listZonesCalls)
+	}
+	if len(api.listDNSRecordsCalls) != 0 {
+		t.Fatalf("expected no DNS record listing when manage is false, got %d", len(api.listDNSRecordsCalls))
+	}
+}
+
+func TestReconcileSkipsUnrelatedZones(t *testing.T) {
+	api := &stubDNSAPI{
+		zones: []cloudflare.Zone{
+			{ID: "zone-example-com", Name: "example.com"},
+			{ID: "zone-example-org", Name: "example.org"},
+			{ID: "zone-unrelated-net", Name: "unrelated.net"},
+		},
+	}
+	engine := NewEngine(api, testLogger(), true, true, false, nil, "tunnel-id", testManagedBy)
+
+	err := engine.Reconcile(context.Background(), []model.RouteSpec{
+		{Key: model.RouteKey{Hostname: "app.example.com"}, Service: "http://app"},
+		{Key: model.RouteKey{Hostname: "api.example.org"}, Service: "http://api"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertZoneQueried(t, api.listDNSRecordsCalls, "zone-example-com")
+	assertZoneQueried(t, api.listDNSRecordsCalls, "zone-example-org")
+	assertZoneNotQueried(t, api.listDNSRecordsCalls, "zone-unrelated-net")
+}
+
+func TestReconcileUsesExplicitOverrideZone(t *testing.T) {
+	api := &stubDNSAPI{
+		zones: []cloudflare.Zone{
+			{ID: "zone-example-com", Name: "example.com"},
+			{ID: "zone-dev-example-com", Name: "dev.example.com"},
+		},
+	}
+	engine := NewEngine(api, testLogger(), true, true, false, nil, "tunnel-id", testManagedBy)
+
+	err := engine.Reconcile(context.Background(), []model.RouteSpec{{
+		Key:             model.RouteKey{Hostname: "app.dev.example.com"},
+		Service:         "http://app",
+		DNSZoneOverride: "dev.example.com",
+	}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertZoneQueried(t, api.listDNSRecordsCalls, "zone-dev-example-com")
+	assertZoneNotQueried(t, api.listDNSRecordsCalls, "zone-example-com")
+}
+
+func TestReconcileSkipsHostnameWhenExplicitOverrideIsInvalid(t *testing.T) {
+	api := &stubDNSAPI{
+		zones: []cloudflare.Zone{{ID: "zone-example-com", Name: "example.com"}},
+	}
+	engine := NewEngine(api, testLogger(), true, true, false, nil, "tunnel-id", testManagedBy)
+
+	err := engine.Reconcile(context.Background(), []model.RouteSpec{{
+		Key:             model.RouteKey{Hostname: "app.example.com"},
+		Service:         "http://app",
+		DNSZoneOverride: "dev.example.com",
+	}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if api.listZonesCalls != 0 {
+		t.Fatalf("expected no zone listing when hostname plan is invalid, got %d", api.listZonesCalls)
+	}
+	if len(api.listDNSRecordsCalls) != 0 {
+		t.Fatalf("expected no DNS record queries when hostname plan is invalid, got %d", len(api.listDNSRecordsCalls))
+	}
+}
+
+func TestReconcileDeleteOnlyTouchesSelectedZones(t *testing.T) {
+	managedComment := model.DNSManagedComment(testManagedBy)
+	api := &stubDNSAPI{
+		zones: []cloudflare.Zone{
+			{ID: "zone-example-com", Name: "example.com"},
+			{ID: "zone-example-org", Name: "example.org"},
+		},
+		recordsByQuery: map[string][]cloudflare.DNSRecord{
+			"zone-example-com|": {
+				{ID: "orphan", Name: "old.example.com", Type: dnsRecordType, Comment: managedComment},
+			},
+			"zone-example-com|app.example.com": {
+				{ID: "managed", Name: "app.example.com", Type: dnsRecordType, Content: "tunnel-id.cfargotunnel.com", Proxied: true, Comment: managedComment},
+			},
+			"zone-example-org|": {
+				{ID: "other-orphan", Name: "old.example.org", Type: dnsRecordType, Comment: managedComment},
+			},
+		},
+	}
+	engine := NewEngine(api, testLogger(), false, true, true, nil, "tunnel-id", testManagedBy)
+
+	err := engine.Reconcile(context.Background(), []model.RouteSpec{{Key: model.RouteKey{Hostname: "app.example.com"}, Service: "http://app"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(api.deleteCalls) != 1 {
+		t.Fatalf("expected exactly one delete call, got %d", len(api.deleteCalls))
+	}
+	if api.deleteCalls[0].zoneID != "zone-example-com" {
+		t.Fatalf("expected delete in example.com zone, got %+v", api.deleteCalls[0])
+	}
+	assertZoneNotQueried(t, api.listDNSRecordsCalls, "zone-example-org")
+}
+
+func TestReconcileDeleteScansConfiguredZonesWithoutRoutes(t *testing.T) {
+	managedComment := model.DNSManagedComment(testManagedBy)
+	api := &stubDNSAPI{
+		zones: []cloudflare.Zone{{ID: "zone-darkdragon-fr", Name: "darkdragon.fr"}},
+		recordsByQuery: map[string][]cloudflare.DNSRecord{
+			"zone-darkdragon-fr|": {
+				{ID: "orphan", Name: "test-cf.darkdragon.fr", Type: dnsRecordType, Comment: managedComment},
+			},
+		},
+	}
+	engine := NewEngine(api, testLogger(), false, true, true, []string{"darkdragon.fr"}, "tunnel-id", testManagedBy)
+
+	err := engine.Reconcile(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if api.listZonesCalls != 1 {
+		t.Fatalf("expected configured cleanup zones to trigger zone listing, got %d", api.listZonesCalls)
+	}
+	if len(api.deleteCalls) != 1 {
+		t.Fatalf("expected configured cleanup zone to delete orphan record, got %d", len(api.deleteCalls))
+	}
+	assertZoneQueried(t, api.listDNSRecordsCalls, "zone-darkdragon-fr")
+	assertZoneNotQueriedForName(t, api.listDNSRecordsCalls, "zone-darkdragon-fr", "test-cf.darkdragon.fr")
+}
+
+func TestReconcileConfiguredZonesIgnoredWhenDeleteDisabled(t *testing.T) {
+	api := &stubDNSAPI{}
+	engine := NewEngine(api, testLogger(), false, true, false, []string{"darkdragon.fr"}, "tunnel-id", testManagedBy)
+
+	err := engine.Reconcile(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if api.listZonesCalls != 0 {
+		t.Fatalf("expected no zone listing when only cleanup zones are configured and delete is false, got %d", api.listZonesCalls)
+	}
+	if len(api.listDNSRecordsCalls) != 0 {
+		t.Fatalf("expected no DNS record queries when delete is false, got %d", len(api.listDNSRecordsCalls))
+	}
+}
+
+func TestReconcileDeleteIncludesConfiguredCleanupZones(t *testing.T) {
+	managedComment := model.DNSManagedComment(testManagedBy)
+	api := &stubDNSAPI{
+		zones: []cloudflare.Zone{
+			{ID: "zone-example-com", Name: "example.com"},
+			{ID: "zone-darkdragon-fr", Name: "darkdragon.fr"},
+		},
+		recordsByQuery: map[string][]cloudflare.DNSRecord{
+			"zone-example-com|": {
+				{ID: "managed", Name: "app.example.com", Type: dnsRecordType, Comment: managedComment},
+			},
+			"zone-example-com|app.example.com": {
+				{ID: "managed", Name: "app.example.com", Type: dnsRecordType, Content: "tunnel-id.cfargotunnel.com", Proxied: true, Comment: managedComment},
+			},
+			"zone-darkdragon-fr|": {
+				{ID: "orphan", Name: "test-cf.darkdragon.fr", Type: dnsRecordType, Comment: managedComment},
+			},
+		},
+	}
+	engine := NewEngine(api, testLogger(), false, true, true, []string{"darkdragon.fr"}, "tunnel-id", testManagedBy)
+
+	err := engine.Reconcile(context.Background(), []model.RouteSpec{{Key: model.RouteKey{Hostname: "app.example.com"}, Service: "http://app"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertZoneQueried(t, api.listDNSRecordsCalls, "zone-example-com")
+	assertZoneQueried(t, api.listDNSRecordsCalls, "zone-darkdragon-fr")
+	if len(api.deleteCalls) != 1 || api.deleteCalls[0].zoneID != "zone-darkdragon-fr" {
+		t.Fatalf("expected configured cleanup zone orphan to be deleted, got %+v", api.deleteCalls)
+	}
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+type dnsListCall struct {
+	zoneID string
+	name   string
+}
+
+type dnsDeleteCall struct {
+	zoneID   string
+	recordID string
+}
+
+type stubDNSAPI struct {
+	zones               []cloudflare.Zone
+	recordsByQuery      map[string][]cloudflare.DNSRecord
+	listZonesCalls      int
+	listDNSRecordsCalls []dnsListCall
+	deleteCalls         []dnsDeleteCall
+}
+
+func (api *stubDNSAPI) ListZones(ctx context.Context) ([]cloudflare.Zone, error) {
+	api.listZonesCalls++
+	return api.zones, nil
+}
+
+func (api *stubDNSAPI) ListDNSRecords(ctx context.Context, zoneID string, recordType string, name string) ([]cloudflare.DNSRecord, error) {
+	api.listDNSRecordsCalls = append(api.listDNSRecordsCalls, dnsListCall{zoneID: zoneID, name: name})
+	if api.recordsByQuery == nil {
+		return nil, nil
+	}
+	return api.recordsByQuery[zoneID+"|"+name], nil
+}
+
+func (api *stubDNSAPI) CreateDNSRecord(ctx context.Context, zoneID string, input cloudflare.DNSRecordInput) (cloudflare.DNSRecord, error) {
+	return cloudflare.DNSRecord{}, nil
+}
+
+func (api *stubDNSAPI) UpdateDNSRecord(ctx context.Context, zoneID string, recordID string, input cloudflare.DNSRecordInput) (cloudflare.DNSRecord, error) {
+	return cloudflare.DNSRecord{}, nil
+}
+
+func (api *stubDNSAPI) DeleteDNSRecord(ctx context.Context, zoneID string, recordID string) error {
+	api.deleteCalls = append(api.deleteCalls, dnsDeleteCall{zoneID: zoneID, recordID: recordID})
+	return nil
+}
+
+func assertZoneQueried(t *testing.T, calls []dnsListCall, zoneID string) {
+	t.Helper()
+	for _, call := range calls {
+		if call.zoneID == zoneID {
+			return
+		}
+	}
+	t.Fatalf("expected zone %s to be queried, got %+v", zoneID, calls)
+}
+
+func assertZoneNotQueried(t *testing.T, calls []dnsListCall, zoneID string) {
+	t.Helper()
+	for _, call := range calls {
+		if call.zoneID == zoneID {
+			t.Fatalf("expected zone %s not to be queried, got %+v", zoneID, calls)
+		}
+	}
+}
+
+func assertZoneNotQueriedForName(t *testing.T, calls []dnsListCall, zoneID string, name string) {
+	t.Helper()
+	for _, call := range calls {
+		if call.zoneID == zoneID && call.name == name {
+			t.Fatalf("expected zone %s not to be queried for %s, got %+v", zoneID, name, calls)
+		}
+	}
+}

--- a/internal/labels/parser.go
+++ b/internal/labels/parser.go
@@ -14,6 +14,7 @@ const (
 	LabelPrefix            = "cloudflare.tunnel."
 	LabelEnable            = LabelPrefix + "enable"
 	LabelHost              = LabelPrefix + "hostname"
+	LabelDNSZone           = LabelPrefix + "dns.zone"
 	LabelPath              = LabelPrefix + "path"
 	LabelService           = LabelPrefix + "service"
 	LabelOriginServerName  = LabelPrefix + "origin.server-name"
@@ -83,11 +84,17 @@ func (parser *Parser) ParseContainers(containers []docker.ContainerInfo) ([]mode
 			continue
 		}
 
+		dnsZone, err := parseDNSZoneLabel(container.Name, container.Labels, LabelDNSZone)
+		if err != nil {
+			errors = append(errors, err)
+		}
+
 		key := model.RouteKey{Hostname: hostname, Path: path}
 		source := model.SourceRef{ContainerID: container.ID, ContainerName: container.Name}
 		if err := appendRouteSpec(&desired, desiredKeys, model.RouteSpec{
 			Key:              key,
 			Service:          service,
+			DNSZoneOverride:  dnsZone,
 			OriginServerName: originServerName,
 			NoTLSVerify:      originNoTLSVerify,
 			Source:           source,
@@ -147,10 +154,17 @@ func (parser *Parser) ParseContainers(containers []docker.ContainerInfo) ([]mode
 				continue
 			}
 
+			dnsZoneKey := LabelDNSZone + "." + suffix
+			dnsZone, err := parseDNSZoneLabel(container.Name, container.Labels, dnsZoneKey)
+			if err != nil {
+				errors = append(errors, err)
+			}
+
 			key := model.RouteKey{Hostname: hostname, Path: path}
 			if err := appendRouteSpec(&desired, desiredKeys, model.RouteSpec{
 				Key:              key,
 				Service:          service,
+				DNSZoneOverride:  dnsZone,
 				OriginServerName: originServerName,
 				NoTLSVerify:      originNoTLSVerify,
 				Source:           source,
@@ -217,6 +231,20 @@ func parseOriginLabels(containerName string, labels map[string]string, serverNam
 	}
 
 	return originServerName, originNoTLSVerify, nil
+}
+
+func parseDNSZoneLabel(containerName string, labels map[string]string, zoneLabel string) (string, error) {
+	zoneValue, hasZone := labels[zoneLabel]
+	if !hasZone {
+		return "", nil
+	}
+
+	trimmed := strings.TrimSpace(zoneValue)
+	if trimmed == "" {
+		return "", fmt.Errorf("container %s: %s cannot be empty", containerName, zoneLabel)
+	}
+
+	return strings.ToLower(strings.TrimSuffix(trimmed, ".")), nil
 }
 
 // ParseAccessContainers returns desired Access apps and any validation errors.

--- a/internal/labels/parser_test.go
+++ b/internal/labels/parser_test.go
@@ -141,6 +141,68 @@ func TestParseContainersWithSuffixRoutes(t *testing.T) {
 	}
 }
 
+func TestParseContainersWithDNSZoneOverride(t *testing.T) {
+	parser := NewParser()
+
+	containers := []docker.ContainerInfo{
+		{
+			ID:   "1",
+			Name: "with-dns-zone",
+			Labels: map[string]string{
+				LabelEnable:  "true",
+				LabelHost:    "app.dev.example.com",
+				LabelService: "http://app:8080",
+				LabelDNSZone: "Dev.Example.Com.",
+			},
+		},
+	}
+
+	routes, errs := parser.ParseContainers(containers)
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got %v", errs)
+	}
+	if len(routes) != 1 {
+		t.Fatalf("expected 1 route, got %d", len(routes))
+	}
+	if routes[0].DNSZoneOverride != "dev.example.com" {
+		t.Fatalf("expected dns zone override to be normalized, got %q", routes[0].DNSZoneOverride)
+	}
+}
+
+func TestParseContainersWithSuffixDNSZoneOverride(t *testing.T) {
+	parser := NewParser()
+
+	containers := []docker.ContainerInfo{
+		{
+			ID:   "1",
+			Name: "suffix-dns-zone",
+			Labels: map[string]string{
+				LabelEnable:           "true",
+				LabelHost:             "app.example.com",
+				LabelService:          "http://app:8080",
+				LabelHost + ".api":    "api.dev.example.com",
+				LabelService + ".api": "http://api:8080",
+				LabelDNSZone + ".api": "dev.example.com",
+				LabelPath + ".api":    "/api",
+			},
+		},
+	}
+
+	routes, errs := parser.ParseContainers(containers)
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got %v", errs)
+	}
+	if len(routes) != 2 {
+		t.Fatalf("expected 2 routes, got %d", len(routes))
+	}
+	if routes[0].DNSZoneOverride != "" {
+		t.Fatalf("expected base route to have no dns zone override, got %q", routes[0].DNSZoneOverride)
+	}
+	if routes[1].DNSZoneOverride != "dev.example.com" {
+		t.Fatalf("expected suffix route dns zone override, got %q", routes[1].DNSZoneOverride)
+	}
+}
+
 func TestParseContainersMissingSuffixService(t *testing.T) {
 	parser := NewParser()
 

--- a/internal/model/route.go
+++ b/internal/model/route.go
@@ -25,6 +25,7 @@ type SourceRef struct {
 type RouteSpec struct {
 	Key              RouteKey
 	Service          string
+	DNSZoneOverride  string
 	OriginServerName *string
 	NoTLSVerify      *bool
 	Source           SourceRef


### PR DESCRIPTION
## Summary
- add per-route DNS zone overrides and automatic eTLD+1 zone selection so DNS sync only queries Cloudflare zones related to managed hostnames
- add `SYNC_DNS_ZONES` so orphan cleanup can keep scanning explicit zones after the last matching label disappears
- document the new DNS behavior and cover config parsing plus DNS cleanup flows with tests

## Testing
- `docker run --rm -u "$(id -u):$(id -g)" -v "/home/darkdragon/docker-docker-cloudflare-tunnel-sync":/workspace -w /workspace golang:1.24 gofmt -w cmd/docker-cloudflare-tunnel-sync/main.go internal/config/config.go internal/config/config_test.go internal/dns/engine.go internal/dns/engine_test.go`
- `docker run --rm -u "$(id -u):$(id -g)" -e HOME=/tmp -e GOCACHE=/tmp/go-build -e GOMODCACHE=/tmp/go-mod -v "/home/darkdragon/docker-docker-cloudflare-tunnel-sync":/workspace -w /workspace golang:1.24 go test ./...`